### PR TITLE
allow json body for posts

### DIFF
--- a/lib/inherits.js
+++ b/lib/inherits.js
@@ -34,9 +34,10 @@
                     url: path,
                     method: method
                 };
+                if (options.json) parameters.json = options.json;
 
                 request(parameters, function(err, response, body) {
-                    return callback(err, JSON.parse(body) || body);
+                    return callback(err, typeof body === 'string' ? JSON.parse(body) : body);
                 });
             }
         };


### PR DESCRIPTION
this allows us to use the POST API endpoints like the share:

```
    var api = linkedin.init(access_token);
    api.people.share = function(share, cb) {
      this.createCall('POST', 'people/~/shares', { json: share }, cb)(this.config);
    };

    api.people.share({
      comment: 'blabla',
      content: { title: 'a', description: 'b', 'submitted-url': 'http://google.ch', 'submitted-image-url': '' },
      visibility: { code: 'anyone' }
    }, function(err, res) {/*..*/});
```
