### PR TITLE
making response objects optional for auth

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,6 +17,12 @@
         this.options = {};
 
         this.authorize = function(res, scope) {
+
+            if(Object.prototype.toString.call(res) == "[object Array]"){
+                scope = res;
+                res = null;
+            }
+
             url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
                 "&client_id=%s" +
                 "&scope=%s" +
@@ -27,10 +33,18 @@
                 Math.random(),
                 args.callback
             );
-            res.redirect(url);
+
+            return res ? res.redirect(url) : url;
         };
 
         this.getAccessToken = function(res, code, cb) {
+
+            if(typeof res == 'string'){
+                cb = code;
+                code = res;
+                res = null;
+            }
+
             url = util.format("https://www.linkedin.com/uas/oauth2/accessToken?grant_type=authorization_code" +
                 "&code=%s" +
                 "&redirect_uri=%s" +


### PR DESCRIPTION
Not everybody use express, or other libraries that use the same patterns expected by the initial `res` argument for authorizing against linkedin via this module.

This PR just makes that argument optional, and lets the implementor decide what to do with the returned `url` if `res` isn't provided.