### PR TITLE
Readme comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,17 @@ var linkedin = Linkedin.init('my_access_token', {
 We regret to use 1.0 for authentication and linkedin also supports 2.0. So lets start using it. The below example is inspired from `express.js` but good enough to give the walkthrough.
 
 ```javascript
+// Using a library like `expressjs` the module will 
+// redirect for you simply by passing `res`.
 app.get('/oauth/linkedin', function(req, res) {
     // This will ask for permisssions etc and redirect to callback url.
     Linkedin.auth.authorize(res, ['r_basicprofile', 'r_fullprofile', 'r_emailaddress', 'r_network', 'r_contactinfo', 'rw_nus', 'rw_groups', 'w_messages']);
 });
 
+// otherwise you can leave `res` out, and the module will respond with the redirect url
+Linkedin.auth.authorize(['r_basicprofile', 'r_fullprofile', 'r_emailaddress', 'r_network', 'r_contactinfo', 'rw_nus', 'rw_groups', 'w_messages']);
+
+// Again, `res` is optional, you could pass `code` as the first parameter
 app.get('/oauth/linkedin/callback', function(req, res) {
     Linkedin.auth.getAccessToken(res, req.query.code, function(err, results) {
         if ( err )

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -63,7 +63,7 @@
 
                 var res = JSON.parse(body);
 
-                if(typeof res.error) {
+                if(typeof res.error !== 'undefined') {
                     err = new Error(res.error_description);
                     err.name = res.error;
                     return cb(err, null);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -23,6 +23,8 @@
                 res = null;
             }
 
+            console.log(args.callback)
+
             url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
                 "&client_id=%s" +
                 "&scope=%s" +
@@ -57,9 +59,20 @@
             );
 
             request.get(url, function(err, response, body) {
+
                 if (err)
                     return cb(err, null);
-                return cb(null, body);
+
+                var res = JSON.parse(body);
+
+                if(typeof res.error) {
+                    err = new Error(res.error_description);
+                    err.name = res.error;
+                    return cb(err, null);
+                }
+
+                return cb(null, res);
+
             })
         };
       

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,6 +17,12 @@
         this.options = {};
 
         this.authorize = function(res, scope) {
+
+            if(Object.prototype.toString.call(res) == "[object Array]"){
+                scope = res;
+                res = null;
+            }
+
             url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
                 "&client_id=%s" +
                 "&scope=%s" +
@@ -27,10 +33,18 @@
                 Math.random(),
                 args.callback
             );
-            res.redirect(url);
+
+            return res ? res.redirect(url) : url;
         };
 
         this.getAccessToken = function(res, code, cb) {
+
+            if(typeof res == 'string'){
+                cb = code;
+                code = res;
+                res = null;
+            }
+
             url = util.format("https://www.linkedin.com/uas/oauth2/accessToken?grant_type=authorization_code" +
                 "&code=%s" +
                 "&redirect_uri=%s" +

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -23,8 +23,6 @@
                 res = null;
             }
 
-            console.log(args.callback)
-
             url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
                 "&client_id=%s" +
                 "&scope=%s" +


### PR DESCRIPTION
Simple readme explanation about optional `res` argument for #26 

LinkedIn response for `getAccessToken` isn't returned as a json object, so converting it to one.

Also, if linkedin returns an error response and it wasn't handled, 4bb4eb88ee converts it to an error object and returns it as the `err` argument in the callback.