### PR TITLE
Allow users to specify what version oauth token they are using

### DIFF
--- a/lib/inherits.js
+++ b/lib/inherits.js
@@ -16,7 +16,10 @@
                     callback = options;
                     options = {};
                 }
-                options.oauth2_access_token = config.accessToken;
+
+                if (config.accessToken.version === 2) {
+                    options.oauth2_access_token = config.accessToken.token;
+                }
                 options.strict = options.strict || false;
                 options.format = config.format;
                 path = url.format({
@@ -35,6 +38,11 @@
                     method: method,
                     timeout: config.timeout || 60 * 1000 /* Default to 60sec */
                 };
+                if (config.accessToken.version === 1) {
+                    parameters.headers = {
+                        oauth_token: config.accessToken.token
+                    };
+                }
                 if (options.json) parameters.json = options.json;
 
                 request(parameters, function(err, response, body) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -24,7 +24,14 @@
             callback: callback
         });
         this.init = function(accessToken, options) {
-            this.options.accessToken = accessToken;
+            if (typeof accessToken === 'string') {
+                this.options.accessToken = {
+                    token: accessToken,
+                    version: 2
+                };
+            } else {
+                this.options.accessToken = accessToken;
+            }
 
             options = options || {};
             this.options.timeout = options.timeout;


### PR DESCRIPTION
This fix allows usage of OAuth v1.0 tokens with LinkedIn. This is important as many libraries (including LinkedIn's own JSSDK) create 1.0 tokens.

The changes are backwards compatible. The new functionality works as follows:

Use an OAuth v1 token:

    var linkedin = LinkedIn.init(
        {token: access_token, version: 1},
        {timeout: 5000}
    );

Use an OAuth v2 token:

    var linkedin = LinkedIn.init(access_token, {timeout: 5000});
