### PR TITLE
Fixed CSRF issue

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -36,11 +36,12 @@
                 res = null;
             }
 
-            state = encodeURIComponent(state || newState());
+            state = state || newState();
             redirectURI = redirectURI || args.callback;
             states[state] = {
                 redirectURI: redirectURI,
             };
+            state = encodeURIComponent(state);
 
             var url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
                 "&client_id=%s" +


### PR DESCRIPTION
State object was being saved in encoded form and was retrieved as decoded one. So it was returning CSRF error when there are special characters in the state.