### PR TITLE
callback support for state setting and validation

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -27,9 +27,10 @@
 
         this.options = {};
 
-        this.authorize = function (res, scope, state, redirectURI) {
+        this.authorize = function (res, scope, state, redirectURI, setState) {
 
             if (res && res.constructor === Array) {
+                setState = redirectURI;
                 redirectURI = state;
                 state = scope;
                 scope = res;
@@ -38,9 +39,7 @@
 
             state = state || newState();
             redirectURI = redirectURI || args.callback;
-            states[state] = {
-                redirectURI: redirectURI,
-            };
+            setState(state);
             state = encodeURIComponent(state);
 
             var url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
@@ -59,7 +58,7 @@
             return res ? res.redirect(url) : url;
         };
 
-        this.getAccessToken = function (res, code, stateOut, cb) {
+        this.getAccessToken = function (res, code, stateValidation, cb) {
 
             if (typeof res == 'string') {
                 cb = stateOut;
@@ -68,41 +67,42 @@
                 res = null;
             }
 
-            var state = states[stateOut];
-
-            if (!state) {
-                var err = new Error('Possible CSRF attack, state parameters do not match.');
-                err.name = 'CSRF Alert';
-                return cb(err, null);
-            }
-
-            delete states[stateOut];
-
-            var url = "https://www.linkedin.com/uas/oauth2/accessToken",
-                form = {
-                    "grant_type": "authorization_code",
-                    "code": code,
-                    "redirect_uri": state.redirectURI,
-                    "client_id": args.appId,
-                    "client_secret": args.appSecret
-                };
-
-            request.post({url: url, form: form}, function (err, response, body) {
-
-                if (err)
-                    return cb(err, null);
-
-                var res = JSON.parse(body);
-
-                if (typeof res.error !== 'undefined') {
-                    err = new Error(res.error_description);
-                    err.name = res.error;
+            stateValidation
+            .then(function(valid) {
+                if (!valid) {
+                    var err = new Error('Possible CSRF attack, state parameters do not match.');
+                    err.name = 'CSRF Alert';
                     return cb(err, null);
                 }
 
-                return cb(null, res);
+                var url = "https://www.linkedin.com/uas/oauth2/accessToken",
+                    form = {
+                        "grant_type": "authorization_code",
+                        "code": code,
+                        "redirect_uri": state.redirectURI,
+                        "client_id": args.appId,
+                        "client_secret": args.appSecret
+                    };
 
+                request.post({url: url, form: form}, function (err, response, body) {
+
+                    if (err)
+                        return cb(err, null);
+
+                    var res = JSON.parse(body);
+
+                    if (typeof res.error !== 'undefined') {
+                        err = new Error(res.error_description);
+                        err.name = res.error;
+                        return cb(err, null);
+                    }
+
+                    return cb(null, res);
+
+                })  
             })
+
+            
         };
 
         this.exchangeAccessToken = function (token, cb) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -42,7 +42,7 @@
             setState(state, redirectURI);
             state = encodeURIComponent(state);
 
-            var url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
+            var url = util.format("https://www.linkedin.com/oauth/v2/authorization?response_type=code" +
                 "&client_id=%s" +
                 "&state=%s" +
                 "&redirect_uri=%s",
@@ -75,7 +75,7 @@
                     return cb(err, null);
                 }
 
-                var url = "https://www.linkedin.com/uas/oauth2/accessToken",
+                var url = "https://www.linkedin.com/oauth/v2/accessToken",
                     form = {
                         "grant_type": "authorization_code",
                         "code": code,

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -39,7 +39,7 @@
 
             state = state || newState();
             redirectURI = redirectURI || args.callback;
-            setState(state);
+            setState(state, redirectURI);
             state = encodeURIComponent(state);
 
             var url = util.format("https://www.linkedin.com/uas/oauth2/authorization?response_type=code" +
@@ -61,15 +61,15 @@
         this.getAccessToken = function (res, code, stateValidation, cb) {
 
             if (typeof res == 'string') {
-                cb = stateOut;
-                stateOut = code;
+                cb = stateValidation;
+                stateValidation = code;
                 code = res;
                 res = null;
             }
 
             stateValidation
-            .then(function(valid) {
-                if (!valid) {
+            .then(function(state) {
+                if (!state) {
                     var err = new Error('Possible CSRF attack, state parameters do not match.');
                     err.name = 'CSRF Alert';
                     return cb(err, null);


### PR DESCRIPTION
This is a fix for the issue here:

https://github.com/ArkeologeN/node-linkedin/issues/56

It requires that users provide their own state setting and validation methods, e.g.:

```
function setLinkedinState(state, redirectURI) {
  return new Promise(function(resolve, reject) {
    CSRFToken.create({
      token:state,
      redirectURI:redirectURI
    })
    .then(function(results) {
      resolve(results);
    })
    .catch(function(err) {
      reject(false);
    })
  });
}

function validateLinkedinState(state) {
  var token;

  return new Promise(function(resolve, reject) {
    CSRFToken.findOne({
      token:state
    })
    .then(function(results) {
      if (results) {
        token = results;
        // delete token
        return CSRFToken.findOneAndRemove({
          token:state
        });
      }
      else {
        return Promise.resolve(true);
      }
    })
    .then(function(results) {
      resolve(token ? results : false);
    })
    .catch(function(err) {
      resolve(false);
    })
  });
}
```

Example calls:

`Linkedin.auth.authorize(scope, null, process.env.LINKEDIN_CALLBACK, setLinkedinState);`

(expects a function for setting state)

`Linkedin.auth.getAccessToken(res, req.query.code, validateLinkedinState(req.query.state))`

(expects a promise resolving in a true/false validation)

The fact that the `stateValidation` method expects a promise is probably a little problematic in this current codebase since it is callback based, but I know there are plans to move this library over to promises, and I was having difficulties getting this to work with my chosen adapter (Mongoose) since this ORM doesn't seem to have a way to not return promises with function calls. So, I expect this might warrant some conversation?

This also assumes that everybody will care about HA (it does away with the old memory-based state tracking completely). I couldn't really settle on a clean way to support both, and I figured that most developers would at least want to future-proof their code for HA, so this breaks backwards compatibility. I know that there is a 2.0 codebase in-the-works too, so I decided not to worry about that for now since it might make sense to implement this feature in the 2.0 codebase, which will obviously break backwards compatibility anyway.